### PR TITLE
Fix backend startup error

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,11 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 3001;
+  await app.listen(port);
+  console.log(`Server running on port ${port}`);
+}
+
+bootstrap();


### PR DESCRIPTION
## Summary
- add NestJS bootstrap file

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6861acabbecc8331b0032d99fe86c6d0