### PR TITLE
Fix Clerk imports and remove Google font

### DIFF
--- a/frontend/app/api/getAuthenticatedUserId/route.ts
+++ b/frontend/app/api/getAuthenticatedUserId/route.ts
@@ -1,8 +1,8 @@
-import { auth } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
-  const { userId, sessionId } = auth();
+  const { userId, sessionId } = await auth();
   if (!sessionId) {
     return NextResponse.json({ id: null }, { status: 401 });
   }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,13 +1,14 @@
 import "../styles/globals.css";
 import { ClerkProvider, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
-import { Inter } from "next/font/google";
+// Using next/font/google would attempt to download fonts during build which
+// fails in environments without internet access. The layout can work without
+// a custom font, so it is omitted here.
 import Image from "next/image";
 import Script from "next/script";
 import styles from "../styles/Header.module.css";
 import Link from "next/link";
 import type { Metadata } from "next";
 
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Clerk with App Router",
@@ -41,7 +42,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <ClerkProvider>
-        <body className={inter.className}>
+        <body>
           <Header />
           <main>{children}</main>
         </body>

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,8 +1,6 @@
-import { authMiddleware } from "@clerk/nextjs";
+import { clerkMiddleware } from "@clerk/nextjs/server";
 
-export default authMiddleware({
-  publicRoutes: ["/", "/api/getAuthenticatedUserId"],
-});
+export default clerkMiddleware();
 
 export const config = {
   matcher: ["/((?!.*\\..*|_next).*)", "/"],


### PR DESCRIPTION
## Summary
- update Clerk middleware import
- use server version of auth helper and await it
- remove `next/font/google` dependency so offline builds succeed

## Testing
- `npm --prefix backend run test`
- `npm --prefix backend run build`
- `npm --prefix frontend run build` *(fails: Missing publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_6861ae468514833185c18d7b88abbeec