### PR TITLE
Load env from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ npm --prefix backend run start:prod
 
 ## Environment variables
 Copy `.env.example` to `.env` in the project root and provide the required
-variables for Clerk and any other services.
+variables for Clerk and any other services. The Next.js configuration loads this
+file automatically so you only need to maintain a single set of variables for
+both the frontend and backend.
 
 ## Deployment on Vercel
 Ensure all Clerk-related environment variables are configured in the Vercel dashboard. At minimum set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` along with the sign-in and sign-up URLs. Missing variables cause the middleware from `@clerk/nextjs` to fail with `MIDDLEWARE_INVOCATION_FAILED` errors.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 


### PR DESCRIPTION
## Summary
- load root `.env` inside `next.config.js`
- document that the root env file is automatically loaded

## Testing
- `npm --prefix frontend run build` *(fails: invalid Clerk publishable key)*

------
https://chatgpt.com/codex/tasks/task_e_6862893f5d3c833183acebc0094d95f8