### PR TITLE
Add exercises and community features

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,21 @@ both the frontend and backend.
 
 ## Deployment on Vercel
 Ensure all Clerk-related environment variables are configured in the Vercel dashboard. At minimum set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` along with the sign-in and sign-up URLs. Missing variables cause the middleware from `@clerk/nextjs` to fail with `MIDDLEWARE_INVOCATION_FAILED` errors.
+
+## Database setup
+The `docs` directory contains SQL files for creating tables in Supabase. Run
+these scripts in your project database before starting the application:
+
+```sql
+-- personal trainer profiles
+\i docs/personal_trainers.sql
+
+-- students managed by each trainer
+\i docs/students.sql
+
+-- exercises created by trainers
+\i docs/exercises.sql
+
+-- plans for each student
+\i docs/plans.sql
+```

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,9 +4,7 @@ import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config/dist/config.module';
 
 @Module({
-  imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
-  ],
+  imports: [ConfigModule.forRoot({ isGlobal: true })],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/docs/exercises.sql
+++ b/docs/exercises.sql
@@ -1,0 +1,23 @@
+-- SQL schema for storing exercises created by trainers
+create table if not exists exercises (
+    id uuid primary key default uuid_generate_v4(),
+    trainer_id uuid references personal_trainers(id) on delete cascade,
+    name text not null,
+    description text,
+    icon text,
+    inserted_at timestamp with time zone default timezone('utc', now()),
+    updated_at timestamp with time zone default timezone('utc', now())
+);
+
+alter table exercises enable row level security;
+
+create policy "Allow trainer" on exercises
+  for all
+  using (trainer_id in (
+    select id from personal_trainers
+    where clerk_user_id = auth.jwt()->>'sub'
+  ))
+  with check (trainer_id in (
+    select id from personal_trainers
+    where clerk_user_id = auth.jwt()->>'sub'
+  ));

--- a/docs/plans.sql
+++ b/docs/plans.sql
@@ -1,0 +1,24 @@
+-- SQL schema for storing class plans for each student
+create table if not exists plans (
+    id uuid primary key default uuid_generate_v4(),
+    student_id uuid references students(id) on delete cascade,
+    previous_plan_id uuid references plans(id),
+    notes text,
+    inserted_at timestamp with time zone default timezone('utc', now()),
+    updated_at timestamp with time zone default timezone('utc', now())
+);
+
+alter table plans enable row level security;
+
+create policy "Trainer access" on plans
+  for all
+  using (student_id in (
+    select students.id from students
+    join personal_trainers on students.trainer_id = personal_trainers.id
+    where personal_trainers.clerk_user_id = auth.jwt()->>'sub'
+  ))
+  with check (student_id in (
+    select students.id from students
+    join personal_trainers on students.trainer_id = personal_trainers.id
+    where personal_trainers.clerk_user_id = auth.jwt()->>'sub'
+  ));

--- a/docs/students.sql
+++ b/docs/students.sql
@@ -1,0 +1,23 @@
+-- SQL schema for storing trainer students
+create table if not exists students (
+    id uuid primary key default uuid_generate_v4(),
+    trainer_id uuid references personal_trainers(id) on delete cascade,
+    full_name text not null,
+    email text not null,
+    type text,
+    inserted_at timestamp with time zone default timezone('utc', now()),
+    updated_at timestamp with time zone default timezone('utc', now())
+);
+
+alter table students enable row level security;
+
+create policy "Allow trainer" on students
+  for all
+  using (trainer_id in (
+    select id from personal_trainers
+    where clerk_user_id = auth.jwt()->>'sub'
+  ))
+  with check (trainer_id in (
+    select id from personal_trainers
+    where clerk_user_id = auth.jwt()->>'sub'
+  ));

--- a/frontend/app/api/community/route.ts
+++ b/frontend/app/api/community/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { data, error } = await supabaseAdmin.from('exercises').select('*');
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ exercises: data }, { status: 200 });
+}

--- a/frontend/app/api/exercises/route.ts
+++ b/frontend/app/api/exercises/route.ts
@@ -1,0 +1,58 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const trainerRes = await supabaseAdmin
+    .from('personal_trainers')
+    .select('id')
+    .eq('clerk_user_id', userId)
+    .single();
+
+  if (trainerRes.error) {
+    return NextResponse.json({ error: trainerRes.error.message }, { status: 500 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('exercises')
+    .select('*')
+    .eq('trainer_id', trainerRes.data.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ exercises: data }, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await request.json();
+  const { name, description, icon } = body;
+  const trainerRes = await supabaseAdmin
+    .from('personal_trainers')
+    .select('id')
+    .eq('clerk_user_id', userId)
+    .single();
+  if (trainerRes.error) {
+    return NextResponse.json({ error: trainerRes.error.message }, { status: 500 });
+  }
+  const { data, error } = await supabaseAdmin
+    .from('exercises')
+    .insert({ trainer_id: trainerRes.data.id, name, description, icon })
+    .select()
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ exercise: data }, { status: 200 });
+}

--- a/frontend/app/community/page.tsx
+++ b/frontend/app/community/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Exercise {
+  id: string
+  name: string
+  description: string | null
+}
+
+export default function Community() {
+  const [allExercises, setAllExercises] = useState<Exercise[]>([])
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/community')
+      if (res.ok) {
+        const data = await res.json()
+        setAllExercises(data.exercises)
+      }
+    }
+    load()
+  }, [])
+
+  const filtered = allExercises.filter((ex) =>
+    ex.name.toLowerCase().includes(query.toLowerCase())
+  )
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Community Exercises</h1>
+      <input
+        className="w-full border p-2 mb-4"
+        placeholder="Search exercises"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <ul className="space-y-2">
+        {filtered.map((ex) => (
+          <li key={ex.id} className="p-4 border rounded">
+            <p className="font-semibold">{ex.name}</p>
+            {ex.description && (
+              <p className="text-sm text-gray-600">{ex.description}</p>
+            )}
+          </li>
+        ))}
+        {filtered.length === 0 && <p>No matching exercises.</p>}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs'
+import { useRouter } from 'next/navigation'
+
+interface Student {
+  id: string
+  full_name: string
+  email: string
+  type: string | null
+}
+
+export default function Dashboard() {
+  const [students, setStudents] = useState<Student[]>([])
+  const [loading, setLoading] = useState(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/students')
+      if (res.status === 401) {
+        router.push('/sign-in')
+        return
+      }
+      const data = await res.json()
+      setStudents(data.students)
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <SignedOut>
+        <div className="text-center">
+          <p className="mb-4">Please sign in to view your dashboard.</p>
+          <SignInButton />
+        </div>
+      </SignedOut>
+      <SignedIn>
+        <h1 className="text-2xl font-bold mb-4">Your Students</h1>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <ul className="space-y-2">
+            {students.map((s) => (
+              <li key={s.id} className="p-4 border rounded">
+                <h3 className="font-semibold">{s.full_name}</h3>
+                <p className="text-sm text-gray-600">{s.email}</p>
+              </li>
+            ))}
+            {students.length === 0 && <p>No students yet.</p>}
+          </ul>
+        )}
+      </SignedIn>
+    </div>
+  )
+}

--- a/frontend/app/exercises/page.tsx
+++ b/frontend/app/exercises/page.tsx
@@ -1,0 +1,100 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs'
+
+interface Exercise {
+  id: string
+  name: string
+  description: string | null
+  icon: string | null
+}
+
+export default function Exercises() {
+  const [exercises, setExercises] = useState<Exercise[]>([])
+  const [form, setForm] = useState({ name: '', description: '', icon: '' })
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/exercises')
+      if (res.ok) {
+        const data = await res.json()
+        setExercises(data.exercises)
+      }
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/exercises', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setExercises([...exercises, data.exercise])
+      setForm({ name: '', description: '', icon: '' })
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <SignedOut>
+        <div className="text-center">
+          <p className="mb-4">Please sign in to manage your exercises.</p>
+          <SignInButton />
+        </div>
+      </SignedOut>
+      <SignedIn>
+        <h1 className="text-2xl font-bold mb-4">Your Exercises</h1>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <ul className="space-y-2 mb-6">
+            {exercises.map((ex) => (
+              <li key={ex.id} className="p-4 border rounded">
+                <p className="font-semibold">{ex.name}</p>
+                {ex.description && <p className="text-sm text-gray-600">{ex.description}</p>}
+              </li>
+            ))}
+            {exercises.length === 0 && <p>No exercises yet.</p>}
+          </ul>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            className="w-full border p-2"
+            name="name"
+            placeholder="Exercise name"
+            value={form.name}
+            onChange={handleChange}
+            required
+          />
+          <textarea
+            className="w-full border p-2"
+            name="description"
+            placeholder="Description"
+            value={form.description}
+            onChange={handleChange}
+          />
+          <input
+            className="w-full border p-2"
+            name="icon"
+            placeholder="Icon URL"
+            value={form.icon}
+            onChange={handleChange}
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Add Exercise
+          </button>
+        </form>
+      </SignedIn>
+    </div>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -39,6 +39,15 @@ export default function Home() {
             </Link>
           </SignedOut>
           <SignedIn>
+            <Link href="/dashboard" className="px-4 py-2 rounded text-blue-600 hover:underline">
+              Dashboard
+            </Link>
+            <Link href="/exercises" className="px-4 py-2 rounded text-blue-600 hover:underline">
+              Exercises
+            </Link>
+            <Link href="/community" className="px-4 py-2 rounded text-blue-600 hover:underline">
+              Community
+            </Link>
             <UserButton afterSignOutUrl="/" />
           </SignedIn>
         </div>


### PR DESCRIPTION
## Summary
- document exercises and plans SQL setup
- create Supabase tables for exercises and plans
- add API route to manage trainer exercises
- add community API and page to browse all exercises
- add exercises management page
- link dashboard, exercises and community from the home page

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run lint`
- `npm --prefix frontend run build` *(fails: invalid Clerk publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b84b1488331984d4cecd8716e6f