### PR TITLE
Add student and planning management

### DIFF
--- a/frontend/app/api/plans/[studentId]/route.ts
+++ b/frontend/app/api/plans/[studentId]/route.ts
@@ -1,0 +1,93 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: Request,
+  { params }: { params: { studentId: string } }
+) {
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // verify trainer owns student
+  const trainerRes = await supabaseAdmin
+    .from('students')
+    .select('trainer_id')
+    .eq('id', params.studentId)
+    .single()
+  if (trainerRes.error) {
+    return NextResponse.json({ error: trainerRes.error.message }, { status: 500 })
+  }
+  const ownerCheck = await supabaseAdmin
+    .from('personal_trainers')
+    .select('id')
+    .eq('id', trainerRes.data.trainer_id)
+    .eq('clerk_user_id', userId)
+    .single()
+  if (ownerCheck.error || !ownerCheck.data) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('plans')
+    .select('*')
+    .eq('student_id', params.studentId)
+    .order('inserted_at', { ascending: true })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ plans: data }, { status: 200 })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { studentId: string } }
+) {
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const body = await request.json()
+  const { notes } = body
+  // verify trainer owns student
+  const trainerRes = await supabaseAdmin
+    .from('students')
+    .select('trainer_id')
+    .eq('id', params.studentId)
+    .single()
+  if (trainerRes.error) {
+    return NextResponse.json({ error: trainerRes.error.message }, { status: 500 })
+  }
+  const ownerCheck = await supabaseAdmin
+    .from('personal_trainers')
+    .select('id')
+    .eq('id', trainerRes.data.trainer_id)
+    .eq('clerk_user_id', userId)
+    .single()
+  if (ownerCheck.error || !ownerCheck.data) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+  }
+
+  const lastPlanRes = await supabaseAdmin
+    .from('plans')
+    .select('id')
+    .eq('student_id', params.studentId)
+    .order('inserted_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const previous_plan_id = lastPlanRes.data?.id || null
+
+  const { data, error } = await supabaseAdmin
+    .from('plans')
+    .insert({ student_id: params.studentId, notes, previous_plan_id })
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ plan: data }, { status: 200 })
+}

--- a/frontend/app/api/students/route.ts
+++ b/frontend/app/api/students/route.ts
@@ -30,3 +30,33 @@ export async function GET() {
 
   return NextResponse.json({ students: data }, { status: 200 });
 }
+
+export async function POST(request: Request) {
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const body = await request.json()
+  const { full_name, email, type } = body
+  const trainerRes = await supabaseAdmin
+    .from('personal_trainers')
+    .select('id')
+    .eq('clerk_user_id', userId)
+    .single()
+
+  if (trainerRes.error) {
+    return NextResponse.json({ error: trainerRes.error.message }, { status: 500 })
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('students')
+    .insert({ trainer_id: trainerRes.data.id, full_name, email, type })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ student: data }, { status: 200 })
+}

--- a/frontend/app/dashboard/[studentId]/page.tsx
+++ b/frontend/app/dashboard/[studentId]/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs'
+
+interface Student {
+  id: string
+  full_name: string
+  email: string
+  type: string | null
+}
+
+export default function StudentPage() {
+  const params = useParams<{ studentId: string }>()
+  const studentId = params.studentId
+  const [student, setStudent] = useState<Student | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/students')
+      if (res.ok) {
+        const data = await res.json()
+        const s = data.students.find((st: Student) => st.id === studentId)
+        setStudent(s)
+      }
+      setLoading(false)
+    }
+    if (studentId) load()
+  }, [studentId])
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <SignedOut>
+        <div className="text-center">
+          <p className="mb-4">Please sign in to view student.</p>
+          <SignInButton />
+        </div>
+      </SignedOut>
+      <SignedIn>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          student && (
+            <div className="space-y-4">
+              <h1 className="text-2xl font-bold">{student.full_name}</h1>
+              <p className="text-gray-600">{student.email}</p>
+              <p className="text-gray-600">{student.type}</p>
+              <Link
+                href={`/dashboard/${studentId}/plans`}
+                className="px-4 py-2 bg-blue-600 text-white rounded inline-block"
+              >
+                View Plans
+              </Link>
+            </div>
+          )
+        )}
+      </SignedIn>
+    </div>
+  )
+}

--- a/frontend/app/dashboard/[studentId]/plans/page.tsx
+++ b/frontend/app/dashboard/[studentId]/plans/page.tsx
@@ -1,0 +1,82 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs'
+
+interface Plan {
+  id: string
+  notes: string | null
+  previous_plan_id: string | null
+}
+
+export default function PlansPage() {
+  const params = useParams<{ studentId: string }>()
+  const studentId = params.studentId
+  const [plans, setPlans] = useState<Plan[]>([])
+  const [notes, setNotes] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/plans/${studentId}`)
+      if (res.ok) {
+        const data = await res.json()
+        setPlans(data.plans)
+      }
+      setLoading(false)
+    }
+    if (studentId) load()
+  }, [studentId])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch(`/api/plans/${studentId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes })
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setPlans([...plans, data.plan])
+      setNotes('')
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <SignedOut>
+        <div className="text-center">
+          <p className="mb-4">Please sign in to view plans.</p>
+          <SignInButton />
+        </div>
+      </SignedOut>
+      <SignedIn>
+        <h1 className="text-2xl font-bold mb-4">Plans</h1>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <ul className="space-y-2 mb-6">
+            {plans.map((p) => (
+              <li key={p.id} className="p-4 border rounded">
+                <p className="font-semibold">Plan {p.id.slice(0, 8)}</p>
+                {p.notes && <p className="text-sm text-gray-600">{p.notes}</p>}
+              </li>
+            ))}
+            {plans.length === 0 && <p>No plans yet.</p>}
+          </ul>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <textarea
+            className="w-full border p-2"
+            placeholder="Notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+            Add Plan
+          </button>
+        </form>
+      </SignedIn>
+    </div>
+  )
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ interface Student {
 export default function Dashboard() {
   const [students, setStudents] = useState<Student[]>([])
   const [loading, setLoading] = useState(true)
+  const [form, setForm] = useState({ full_name: '', email: '', type: '' })
   const router = useRouter()
 
   useEffect(() => {
@@ -30,6 +31,24 @@ export default function Dashboard() {
     load()
   }, [router])
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/students', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setStudents([...students, data.student])
+      setForm({ full_name: '', email: '', type: '' })
+    }
+  }
+
   return (
     <div className="max-w-4xl mx-auto p-4">
       <SignedOut>
@@ -43,15 +62,46 @@ export default function Dashboard() {
         {loading ? (
           <p>Loading...</p>
         ) : (
-          <ul className="space-y-2">
+          <ul className="space-y-2 mb-6">
             {students.map((s) => (
               <li key={s.id} className="p-4 border rounded">
-                <h3 className="font-semibold">{s.full_name}</h3>
+                <h3 className="font-semibold">
+                  <a href={`/dashboard/${s.id}`}>{s.full_name}</a>
+                </h3>
                 <p className="text-sm text-gray-600">{s.email}</p>
               </li>
             ))}
             {students.length === 0 && <p>No students yet.</p>}
           </ul>
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <input
+              className="w-full border p-2"
+              name="full_name"
+              placeholder="Full name"
+              value={form.full_name}
+              onChange={handleChange}
+              required
+            />
+            <input
+              className="w-full border p-2"
+              name="email"
+              type="email"
+              placeholder="Email"
+              value={form.email}
+              onChange={handleChange}
+              required
+            />
+            <input
+              className="w-full border p-2"
+              name="type"
+              placeholder="Type"
+              value={form.type}
+              onChange={handleChange}
+            />
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+              Add Student
+            </button>
+          </form>
         )}
       </SignedIn>
     </div>


### PR DESCRIPTION
## Summary
- allow personal trainers to create students
- add REST endpoints for student creation and per-student plans
- link to individual student pages and manage plans
- provide UI forms for adding students and plans

## Testing
- `npm --prefix backend run test`

------
https://chatgpt.com/codex/tasks/task_e_686b21f666e88331a1ad2f0649e98860